### PR TITLE
Update for the new file tree implementation

### DIFF
--- a/src/archivetree.cpp
+++ b/src/archivetree.cpp
@@ -73,7 +73,9 @@ void ArchiveTreeWidgetItem::setData(int column, int role, const QVariant& value)
   QTreeWidgetItem::setData(column, role, value);
   if (tree != nullptr && tree->m_Emitter == this) {
     tree->m_Emitter = nullptr;
-    tree->emitTreeCheckStateChanged(this);
+    if (role == Qt::CheckStateRole) {
+      tree->emitTreeCheckStateChanged(this);
+    }
   }
 }
 

--- a/src/archivetree.h
+++ b/src/archivetree.h
@@ -22,34 +22,146 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QTreeWidget>
 
+#include "ifiletree.h"
+
+class ArchiveTreeWidget;
+
+/**
+ * @brief Custom tree widget that holds a shared pointer to the file tree entry
+ * they represent.
+ */
+class ArchiveTreeWidgetItem : public QTreeWidgetItem {
+public:
+
+  ArchiveTreeWidgetItem(std::nullptr_t = nullptr);
+  ArchiveTreeWidgetItem(std::shared_ptr<MOBase::FileTreeEntry> entry);
+  ArchiveTreeWidgetItem(ArchiveTreeWidgetItem* parent, std::shared_ptr<MOBase::FileTreeEntry> entry);
+  ArchiveTreeWidgetItem(ArchiveTreeWidget* parent, std::shared_ptr<MOBase::FileTreeEntry> entry);
+
+public:
+
+  /**
+   * @brief Populate this tree widget item.
+   */
+  void populate();
+
+  /**
+   * @brief Check if this item has been populated already.
+   *
+   * @return true if this item has been populated, false otherwize.
+   */
+  bool isPopulated() const {
+    return m_Populated;
+  }
+
+  /**
+   * @brief Replace the entry corresponding to this item.
+   *
+   * @param entry The new entry.
+   */
+  void setEntry(std::shared_ptr<MOBase::FileTreeEntry> entry) {
+    m_Entry = entry;
+  }
+
+  /**
+   * @brief Retrieve the entry corresponding to this item.
+   *
+   * @return the entry corresponding to this item.
+   */
+  std::shared_ptr<MOBase::FileTreeEntry> entry() const {
+    return m_Entry;
+  }
+
+  /**
+   * @brief Overriden method to avoid propagating dataChanged events.
+   *
+   */
+  void setData(int column, int role, const QVariant& value) override;
+
+protected:
+
+  // The entry of the item:
+  std::shared_ptr<MOBase::FileTreeEntry> m_Entry;
+
+  // Populated or not (when expanded):
+  bool m_Populated = false;
+
+  friend class ArchiveTreeWidget;
+};
+
+
 /**
  * @brief QT tree widget used to display the content of an archive in the manual installation dialog
  **/
-class ArchiveTree : public QTreeWidget
+class ArchiveTreeWidget : public QTreeWidget
 {
 
   Q_OBJECT
 
 public:
 
-  explicit ArchiveTree(QWidget *parent = 0);
+  /**
+   * @brief Default constructor for the UI.
+   *
+   */
+  explicit ArchiveTreeWidget(QWidget *parent = 0);
 
 signals:
 
-  void changed();
+  /**
+   * @brief Emitted after a tree widget item is moved from one
+   * parent to another.
+   *
+   * @param source The item being moved.
+   * @param target The item to which the source is added.
+   *
+   */
+  void itemMoved(ArchiveTreeWidgetItem *source, ArchiveTreeWidgetItem *target);
+
+  /**
+   * @brief Emitted when a tree widget item is checked or unchecked.
+   *
+   * Unlike itemChanged() or dataChanged(), this signal is only emitted
+   * for the item that was changed, not its parent or child.
+   *
+   * This signal is emitted after the tree has been updated, and after all the 
+   * itemChanged() or dataChanged() signals.
+   *
+   * @param item Item that was triggered the change.
+   */
+  void treeCheckStateChanged(ArchiveTreeWidgetItem* item);
 
 public slots:
 
 protected:
 
-  virtual void dragEnterEvent(QDragEnterEvent *event);
-  virtual void dragMoveEvent(QDragMoveEvent *event);
-  virtual void dropEvent(QDropEvent *event);
-  virtual void dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles = QVector<int>());
+  /**
+   * @brief Slot that trigger the given item to be populated if it has not already
+   *     been.
+   *
+   * @param item The item to populate.
+   */
+  virtual void populateItem(QTreeWidgetItem* item);
+
+  virtual void dragEnterEvent(QDragEnterEvent *event) override;
+  virtual void dragMoveEvent(QDragMoveEvent *event) override;
+  virtual void dropEvent(QDropEvent *event) override;
 
 private:
 
   bool testMovePossible(QTreeWidgetItem *source, QTreeWidgetItem *target);
+
+  /**
+   * @brief Emit the itemCheckStateChanged event.
+   * 
+   * @param item Item that was changed.
+   */
+  void emitTreeCheckStateChanged(ArchiveTreeWidgetItem* item);
+
+  // The widget item that emitted the dataChanged event:
+  ArchiveTreeWidgetItem* m_Emitter = nullptr;
+
+  friend class ArchiveTreeWidgetItem;
 
 };
 

--- a/src/installdialog.cpp
+++ b/src/installdialog.cpp
@@ -336,12 +336,11 @@ void InstallDialog::on_treeContent_customContextMenuRequested(QPoint pos)
 
   QMenu menu;
 
-  if (m_ViewRoot->entry() == m_TreeRoot->entry()) {
-    if (selectedItem != m_ViewRoot && selectedItem->entry()->isDir()) {
-      menu.addAction(tr("Set as data directory"), [this, selectedItem]() { setDataRoot(selectedItem); });
-    }
+  if (selectedItem != m_ViewRoot && selectedItem->entry()->isDir()) {
+    menu.addAction(tr("Set as data directory"), [this, selectedItem]() { setDataRoot(selectedItem); });
   }
-  else {
+
+  if (m_ViewRoot->entry() != m_TreeRoot->entry()) {
     menu.addAction(tr("Unset data directory"), [this]() { setDataRoot(m_TreeRoot); });
   }
 

--- a/src/installdialog.cpp
+++ b/src/installdialog.cpp
@@ -91,7 +91,6 @@ InstallDialog::InstallDialog(std::shared_ptr<IFileTree> tree, const GuessedValue
   // Connect the tree slots:
   connect(m_Tree, &ArchiveTreeWidget::treeCheckStateChanged, this, &InstallDialog::onTreeCheckStateChanged);
   connect(m_Tree, &ArchiveTreeWidget::itemMoved, this, &InstallDialog::onItemMoved);  
-  connect(m_Tree, &ArchiveTreeWidget::itemChanged, this, &InstallDialog::onItemChanged);
 
   // Retrieve the label to display problems:
   m_ProblemLabel = findChild<QLabel*>("problemLabel");

--- a/src/installdialog.h
+++ b/src/installdialog.h
@@ -20,11 +20,10 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef INSTALLDIALOG_H
 #define INSTALLDIALOG_H
 
-#include "mytree.h"
 #include "archivetree.h"
 #include "tutorabledialog.h"
 #include <guessedvalue.h>
-#include <directorytree.h>
+#include <ifiletree.h>
 #include <QDialog>
 #include <QUuid>
 #include <QTreeWidgetItem>
@@ -48,14 +47,15 @@ class InstallDialog : public MOBase::TutorableDialog
 
 public:
   /**
-   * @brief constructor
+   * @brief Create a new install dialog for the given tree. The tree
+   * is "own" by the dialog, i.e., any change made by the user is immediately
+   * reflected to the given tree, except for the changes to the root.
    *
-   * @param tree tree structure describing the vanilla archive structure. The InstallDialog
-   *        does NOT take custody of this pointer but it has to remain valid until after the call to getModifiedTree
-   * @param modName name of the mod. The name can be modified through the dialog
-   * @param parent parent widget
+   * @param tree Tree structure describing the original archive structure.
+   * @param modName name of the mod. The name can be modified through the dialog.
+   * @param parent parent widget.
    **/
-  explicit InstallDialog(MOBase::DirectoryTree *tree, const MOBase::GuessedValue<QString> &modName, QWidget *parent = 0);
+  explicit InstallDialog(std::shared_ptr<MOBase::IFileTree> tree, const MOBase::GuessedValue<QString> &modName, QWidget *parent = 0);
   ~InstallDialog();
 
   /**
@@ -66,58 +66,83 @@ public:
   QString getModName() const;
 
   /**
-   * @brief retrieve the user-modified directory structure
+   * @brief Retrieve the user-modified directory structure.
    *
-   * @return modified data structure. This is a NEW datatree object for which the caller takes custody
+   * @return the new tree represented by this dialog, which can be a new
+   *     tree or a subtree of the original tree.
    **/
-  MOBase::DirectoryTree *getModifiedTree() const;
+  std::shared_ptr<MOBase::IFileTree> getModifiedTree() const;
 
 signals:
 
-  void openFile(const QString fileName);
+  /**
+   * @brief Signal emitted when user request the file corresponding
+   *     to the given entry to be opened.
+   *
+   * @param entry Entry corresponding to the file to open.
+   */
+  void openFile(const MOBase::FileTreeEntry *entry);
 
 private:
 
-  void updatePreview();
   bool testForProblem();
   void updateProblems();
 
-  void setDataRoot(QTreeWidgetItem* root);
+  /**
+   * @brief Set the data root widget.
+   */
+  void setDataRoot(ArchiveTreeWidgetItem* const root);
 
-  //void updateFileList(QTreeWidgetItem *item, QString targetName, FileData* const *fileData, size_t size) const;
+  /**
+   * @brief Unset the currently used data.
+   */
+  void unsetData();
 
-  void updateCheckState(QTreeWidgetItem *item);
+  /**
+   * @brief Use the given tree item as the data folder.
+   * 
+   * @param treeItem The item to use.
+   */
+  void useAsData(ArchiveTreeWidgetItem *treeItem);
 
-  void addDataToTree(MOBase::DirectoryTree::Node *node, QTreeWidgetItem *treeItem);
-
-  void mapDataNode(MOBase::DirectoryTree::Node *node, QTreeWidgetItem *baseItem) const;
+  /**
+   * @brief Create a directory under the given tree item, asking
+   *     the user for a name.
+   *
+   * @param treeItem Parent item of the directory.
+   */
+  void createDirectoryUnder(ArchiveTreeWidgetItem *treeItem);
 
 private slots:
 
+  // The two slots to connect to the tree:
+  void onItemMoved(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target);
+  void onItemChanged(QTreeWidgetItem* item, int column);
+  void onTreeCheckStateChanged(ArchiveTreeWidgetItem* item);
+
+  // Automatic slots that are directly bound to the UI:
   void on_treeContent_customContextMenuRequested(QPoint pos);
-
-  void unset_data();
-  void use_as_data();
-  void create_directory();
-  void open_file();
-
-  void treeChanged();
-
   void on_cancelButton_clicked();
-
   void on_okButton_clicked();
 
 private:
   Ui::InstallDialog *ui;
 
-  MOBase::DirectoryTree *m_DataTree;
-
-  ArchiveTree *m_Tree;
+  ArchiveTreeWidget *m_Tree;
   QLabel *m_ProblemLabel;
-  QTreeWidgetItem *m_TreeRoot;
-  QTreeWidgetItem *m_DataRoot;
-  QTreeWidgetItem *m_TreeSelection;
-  bool m_Updating;
+
+  // The tree root is the initial root that will never change (should be const
+  // but cannot be since the parent tree cannot be consstructed in the member
+  // initializer list):
+  ArchiveTreeWidgetItem *m_TreeRoot;
+
+  // The data root is the real widget of the current data. This widget
+  // is not the real root that is added to the tree.
+  ArchiveTreeWidgetItem *m_DataRoot;
+
+  // This is the actual tree in the widget  (should be const but cannot be since 
+  // the parent tree cannot be consstructed in the member initializer list):
+  ArchiveTreeWidgetItem *m_ViewRoot;
 
 };
 

--- a/src/installdialog.h
+++ b/src/installdialog.h
@@ -89,21 +89,43 @@ private:
   void updateProblems();
 
   /**
+   * @brief Detach the entry of this item from its parent, and recursively detach
+   *     all of its parent if they become empty.
+   *
+   * @param item The item to detach.
+   */
+  void detachParents(ArchiveTreeWidgetItem* item);
+
+  /**
+   * @brief Re-attach the entry of this item to its parent, and recursively attach
+   *    all of its parent if they were empty (and thus detached).
+   *
+   * @param item The item to attach.
+   */
+  void attachParents(ArchiveTreeWidgetItem* item);
+
+  /**
+   * @brief Recursively re-insert all the entries below the given item in their
+   *     corresponding parents. This method does not recurse in items that have not 
+   *     been populated yet.
+   *
+   * @param item The top-level item to start.
+   */
+  void recursiveInsert(ArchiveTreeWidgetItem* item);
+
+  /**
+   * @brief Recursively detach all the entries below the given item from their
+   *     corresponding parents. This method does not recurse in items that have not 
+   *     been populated yet.
+   *
+   * @param item The top-level item to start.
+   */
+  void recursiveDetach(ArchiveTreeWidgetItem* item);
+
+  /**
    * @brief Set the data root widget.
    */
   void setDataRoot(ArchiveTreeWidgetItem* const root);
-
-  /**
-   * @brief Unset the currently used data.
-   */
-  void unsetData();
-
-  /**
-   * @brief Use the given tree item as the data folder.
-   * 
-   * @param treeItem The item to use.
-   */
-  void useAsData(ArchiveTreeWidgetItem *treeItem);
 
   /**
    * @brief Create a directory under the given tree item, asking
@@ -117,7 +139,6 @@ private slots:
 
   // The two slots to connect to the tree:
   void onItemMoved(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target);
-  void onItemChanged(QTreeWidgetItem* item, int column);
   void onTreeCheckStateChanged(ArchiveTreeWidgetItem* item);
 
   // Automatic slots that are directly bound to the UI:
@@ -130,6 +151,9 @@ private:
 
   ArchiveTreeWidget *m_Tree;
   QLabel *m_ProblemLabel;
+
+  // IMPORTANT: If you intend to work on this and understand this, read the detailed
+  // explanation at the beginning of the installdialog.cpp file.
 
   // The tree root is the initial root that will never change (should be const
   // but cannot be since the parent tree cannot be consstructed in the member

--- a/src/installdialog.ui
+++ b/src/installdialog.ui
@@ -64,7 +64,7 @@
        </widget>
       </item>
       <item>
-       <widget class="ArchiveTree" name="treeContent">
+       <widget class="ArchiveTreeWidget" name="treeContent">
         <property name="contextMenuPolicy">
          <enum>Qt::CustomContextMenu</enum>
         </property>
@@ -152,7 +152,7 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ArchiveTree</class>
+   <class>ArchiveTreeWidget</class>
    <extends>QTreeWidget</extends>
    <header>archivetree.h</header>
   </customwidget>

--- a/src/installermanual.h
+++ b/src/installermanual.h
@@ -47,22 +47,23 @@ public:
   virtual unsigned int priority() const;
   virtual bool isManualInstaller() const;
 
-  virtual bool isArchiveSupported(const MOBase::DirectoryTree &tree) const;
-  virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, MOBase::DirectoryTree &tree,
+  virtual bool isArchiveSupported(std::shared_ptr<const MOBase::IFileTree> tree) const;
+  virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, std::shared_ptr<MOBase::IFileTree> &tree,
                                  QString &version, int &modID);
 
 private:
 
-  bool isSimpleArchiveTopLayer(const MOBase::DirectoryTree::Node *node) const;
-  const MOBase::DirectoryTree::Node *getSimpleArchiveBase(const MOBase::DirectoryTree &dataTree) const;
+  bool isSimpleArchiveTopLayer(const std::shared_ptr<const MOBase::IFileTree> tree) const;
+  std::shared_ptr<const MOBase::IFileTree> getSimpleArchiveBase(const std::shared_ptr<const MOBase::IFileTree> tree) const;
 
 private slots:
 
   /**
-   * @brief opens a file from the archive in the (system-)default editor/viewer
-   * @param fileName relative name of the file to open
+   * @brief Opens a file from the archive in the (system-)default editor/viewer.
+   *
+   * @param entry Entry corresponding to the file to open.
    */
-  void openFile(const QString &fileName);
+  void openFile(const MOBase::FileTreeEntry* entry);
 
 private:
 


### PR DESCRIPTION
**Important:** This PR depends on https://github.com/ModOrganizer2/modorganizer-uibase/pull/48

Content of the PR:
- Modification of the installer for the new file tree implementation.

**Note:** This installer is the one that has been the most impact by the new file tree implementation, but this was by choice. 

The previous version of the installer worked as follow:

1. From the `DirectoryTree`, creates the whole Qt tree, and then forget about the `DirectoryTree`.
2. When the user click on "Install", creates a new `DirectoryTree` from the current content of the Qt tree and replace the old `DirectoryTree` with the new one.

The new version works differently:
- The Qt tree is directly linked with the underlying `IFileTree`, meaning that any change to the tree in the interface is directly reflect to the underlying `IFileTree`. 
    - The main advantage of this is that at any time, the `IFileTree` represent the actual tree presented to the user, so this tree can then be used to check the validity of the installation. Previously, the validity was checked using the `QTreeWidget`, which made it a bit harder to interface with, e.g., a game plugin function "checkMod" (could have been possible by having a different `IFileTree` implementation for this).
- The issue with this is that it's quite complicated to reflect the change to the `IFileTree` without too much performance impact. The code contains comments explaining the various process and choices (e.g., why not use `itemChanged` or `dataChanged`).
- One advantage of these changes is that the new `QTreeWidget` is dynamically populated, meaning that an item is only populated when needed (expanded by the user, directory created, file moved, etc.), meaning that huge archive can be open quite quickly.
