### PR TITLE
Fix drag&drop of in install dialog.

### DIFF
--- a/src/archivetree.cpp
+++ b/src/archivetree.cpp
@@ -25,10 +25,45 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <ifiletree.h>
 #include <log.h>
+#include <report.h>
 
-/**
- * This is the constructor for the top-level item which is a fake item:
- */
+using namespace MOBase;
+
+// Implementation details for the ArchiveTree widget:
+//
+// The ArchiveTreeWidget presents to the user the underlying IFileTree, but in order
+// to increase performance, the tree is populated dynamically when required. Populating
+// the tree is currently required:
+//   1) when a branch of the tree widget is expanded,
+//   2) when an item is moved to a tree,
+//   3) when a directory is created,
+//   4) when a directory is "set as data root".
+//
+// Case 1 is handled automatically in the setExpanded method of ArchiveTreeWidget. Cases 2
+// and 3 could be dealt with differently, but populating the tree before inserting an item
+// makes everything else easier (not that populating the widget is different from populating
+// the IFileTree which is done automatically). Case 4 is handled manually in setDataRoot.
+//
+// Another specificity of the implementation is the treeCheckStateChanged() signal emitted
+// by the ArchiveTreeWidget. This signal is used to avoid having to connect to the itemChanged()
+// signal or overriding the dataChanged() method which are called much more often than those.
+// The treeCheckStateChanged() signal is send only for the item that has actually been changed
+// by the user. While the interface is automatically updated by Qt, we need to update the
+// underlying tree manually. This is done by doing the following things:
+//   1) When an item is unchecked:
+//      - We detach the corresponding entry from its parent, and recursively detach the empty
+//        parents (or the ones that become empty).
+//      - If the entry is a directory and the item has been populated, we recursively detach
+//        all the child entries for all the child items that have been populated (no need to
+//        do it for non-populated items)>
+//   2) When an item is checked, we do the same process but we re-attach parents and re-insert
+//      children.
+//
+// Detaching or re-attaching parents is also done when a directory is created (if the directory
+// is created in an empty directory, we need to re-attach), or when an item is moved (if the
+// directory the item comes from is now empty or if the target directory was empty).
+//
+
 ArchiveTreeWidgetItem::ArchiveTreeWidgetItem(QString dataName)
   : QTreeWidgetItem(QStringList(dataName)), m_Entry(nullptr) {
   setFlags(flags() & ~Qt::ItemIsUserCheckable);
@@ -50,18 +85,6 @@ ArchiveTreeWidgetItem::ArchiveTreeWidgetItem(std::shared_ptr<MOBase::FileTreeEnt
   setToolTip(0, entry->path());
 }
 
-ArchiveTreeWidgetItem::ArchiveTreeWidgetItem(ArchiveTreeWidgetItem* parent, std::shared_ptr<MOBase::FileTreeEntry> entry)
-  : ArchiveTreeWidgetItem(entry)
-{
-  parent->addChild(this);
-}
-
-ArchiveTreeWidgetItem::ArchiveTreeWidgetItem(ArchiveTreeWidget* parent, std::shared_ptr<MOBase::FileTreeEntry> entry)
-  : ArchiveTreeWidgetItem(entry)
-{
-  parent->addTopLevelItem(this);
-}
-
 void ArchiveTreeWidgetItem::setData(int column, int role, const QVariant& value)
 {
   ArchiveTreeWidget* tree = static_cast<ArchiveTreeWidget*>(treeWidget());
@@ -72,7 +95,7 @@ void ArchiveTreeWidgetItem::setData(int column, int role, const QVariant& value)
   if (tree != nullptr && tree->m_Emitter == this) {
     tree->m_Emitter = nullptr;
     if (role == Qt::CheckStateRole) {
-      tree->emitTreeCheckStateChanged(this);
+      tree->onTreeCheckStateChanged(this);
     }
   }
 }
@@ -96,7 +119,7 @@ void ArchiveTreeWidgetItem::populate(bool force) {
   for (auto &entry: *entry()->astree()) {
     auto newItem = new ArchiveTreeWidgetItem(entry);
     newItem->setCheckState(0, flags().testFlag(Qt::ItemIsUserCheckable) ? checkState(0) : Qt::Checked);
-    QTreeWidgetItem::addChild(newItem);
+    addChild(newItem);
   }
 
   // If the item is unchecked, we need to clear it because it has not been cleared
@@ -115,14 +138,170 @@ ArchiveTreeWidget::ArchiveTreeWidget(QWidget *parent) : QTreeWidget(parent)
   connect(this, &ArchiveTreeWidget::itemExpanded, this, &ArchiveTreeWidget::populateItem);
 }
 
+void ArchiveTreeWidget::setup(QString dataFolderName)
+{
+  m_ViewRoot = new ArchiveTreeWidgetItem("<" + dataFolderName + ">");
+  m_DataRoot = nullptr;
+  addTopLevelItem(m_ViewRoot);
+}
+
 void ArchiveTreeWidget::populateItem(QTreeWidgetItem* item)
 {
   static_cast<ArchiveTreeWidgetItem*>(item)->populate();
 }
 
-void ArchiveTreeWidget::emitTreeCheckStateChanged(ArchiveTreeWidgetItem* item)
+void ArchiveTreeWidget::setDataRoot(ArchiveTreeWidgetItem* const root)
 {
-  emit treeCheckStateChanged(item);
+  if (root != m_DataRoot) {
+    if (m_DataRoot != nullptr) {
+      m_DataRoot->addChildren(m_ViewRoot->takeChildren());
+    }
+
+    // Force populate:
+    root->populate();
+
+    m_DataRoot = root;
+    m_ViewRoot->setEntry(m_DataRoot->entry());
+    m_ViewRoot->addChildren(m_DataRoot->takeChildren());
+    m_ViewRoot->setExpanded(true);
+  }
+
+  emit treeChanged();
+}
+
+void ArchiveTreeWidget::detachParents(ArchiveTreeWidgetItem* item) {
+  auto entry = item->entry();
+  auto parent = entry->parent();
+  entry->detach();
+  while (parent != nullptr && parent->empty()) {
+    auto tmp = parent->parent();
+    parent->detach();
+    parent = tmp;
+  }
+
+}
+
+void ArchiveTreeWidget::attachParents(ArchiveTreeWidgetItem* item) {
+  while (item->parent() != nullptr) {
+    auto parent = static_cast<ArchiveTreeWidgetItem*>(item->parent());
+    auto parentEntry = parent->entry();
+    if (parentEntry != nullptr) {
+      parentEntry->astree()->insert(item->entry());
+    }
+    item = parent;
+  }
+}
+
+
+void ArchiveTreeWidget::recursiveInsert(ArchiveTreeWidgetItem* item) {
+  if (item->isPopulated()) {
+    auto tree = item->entry()->astree();
+    for (int i = 0; i < item->childCount(); ++i) {
+      auto child = static_cast<ArchiveTreeWidgetItem*>(item->child(i));
+      tree->insert(child->entry());
+      if (child->entry()->isDir()) {
+        recursiveInsert(child);
+      }
+    }
+  }
+}
+
+void ArchiveTreeWidget::recursiveDetach(ArchiveTreeWidgetItem* item) {
+  if (item->isPopulated()) {
+    for (int i = 0; i < item->childCount(); ++i) {
+      auto child = static_cast<ArchiveTreeWidgetItem*>(item->child(i));
+      if (child->entry()->isDir()) {
+        recursiveDetach(child);
+      }
+    }
+    item->entry()->astree()->clear();
+  }
+}
+
+ArchiveTreeWidgetItem* ArchiveTreeWidget::addDirectory(ArchiveTreeWidgetItem* item, QString name)
+{
+  auto tree = item->entry()->astree();
+  auto* newItem = new ArchiveTreeWidgetItem(tree->addDirectory(name));
+
+  // find the insert position
+  auto it = std::find_if(tree->begin(), tree->end(), [name](auto&& entry) {
+    return entry->compare(name) == 0;
+  });
+  int index = it - tree->begin();
+  MOBase::log::debug("insert at: {}", index);
+  item->insertChild(index, newItem);
+
+  newItem->setCheckState(0, Qt::Checked);
+  attachParents(item);
+  emit treeChanged();
+
+  return newItem;
+}
+
+void ArchiveTreeWidget::moveItem(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target) {
+  // just insert the source in the target.
+  auto tree = target->entry()->astree();
+
+  detachParents(source);
+
+  // check if an entry exists with the same name, we check
+  // in the tree widget to find unchecked items
+  for (int i = 0; i < target->childCount(); ++i) {
+    auto* child = target->child(i);
+    if (child->entry()->compare(source->entry()->name()) == 0) {
+      // remove existing file and force check existing directory
+      if (child->entry()->isFile()) {
+        target->removeChild(child);
+      }
+      else {
+        child->setCheckState(0, Qt::Checked);
+      }
+      break;
+    }
+  }
+
+  tree->insert(source->entry(), IFileTree::InsertPolicy::MERGE);
+
+  attachParents(target);
+
+  emit treeChanged();
+}
+
+void ArchiveTreeWidget::onTreeCheckStateChanged(ArchiveTreeWidgetItem* item) {
+
+  auto entry = item->entry();
+
+  // If the entry is a directory, we need to either detach or re-attach all the
+  // children. It is not possible to only detach the directory because if the
+  // user uncheck a directory and then check a file under it, the other files would
+  // still be attached.
+  //
+  // The two recursive methods only go down to the expanded (based on isPopulated() tree, for
+  // two reasons:
+  //   1. If a tree item has not been populated, then detaching an entry from its parent will
+  //      delete it since there would be no remaining shared pointers.
+  //   2. If the tree has not been populated yet, all the entries under it are still attached,
+  //      so there is no need to process them differently. Detaching a non-expanded item can
+  //      be done by simply detaching the tree, no need to detach all the children.
+  if (entry->isDir()) {
+    if (item->checkState(0) == Qt::Checked && item->isPopulated()) {
+      recursiveInsert(item);
+    }
+    else if (item->checkState(0) == Qt::Unchecked && item->isPopulated()) {
+      recursiveDetach(item);
+    }
+  }
+
+  // Unchecked: we go up the parent chain removing all trees that are now empty:
+  if (item->checkState(0) == Qt::Unchecked) {
+    detachParents(item);
+  }
+  // Otherwize, we need to-reattach the parent:
+  else {
+    attachParents(item);
+  }
+
+  emit treeChanged();
 }
 
 bool ArchiveTreeWidget::testMovePossible(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target)
@@ -279,7 +458,7 @@ void ArchiveTreeWidget::dropEvent(QDropEvent *event)
     source->parent()->removeChild(source);
 
     // actually perform the move on the underlying tree model
-    emit itemMoved(aSource, target);
+    moveItem(aSource, target);
   }
 
   // refresh the target item - this assumes that itemMoved is called synchronously

--- a/src/archivetree.cpp
+++ b/src/archivetree.cpp
@@ -101,7 +101,7 @@ void ArchiveTreeWidgetItem::populate(bool force) {
 
   // If the item is unchecked, we need to clear it because it has not been cleared
   // before:
-  if (checkState(0) == Qt::Unchecked) {
+  if (flags().testFlag(Qt::ItemIsUserCheckable) && checkState(0) == Qt::Unchecked) {
     entry()->astree()->clear();
   }
 

--- a/src/archivetree.h
+++ b/src/archivetree.h
@@ -26,10 +26,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 class ArchiveTreeWidget;
 
-/**
- * @brief Custom tree widget that holds a shared pointer to the file tree entry
- * they represent.
- */
+// custom tree widget that holds a shared pointer to the file tree entry
+// they represent
+//
 class ArchiveTreeWidgetItem : public QTreeWidgetItem {
 public:
 
@@ -40,59 +39,50 @@ public:
 
 public:
 
-  /**
-   * @brief Populate this tree widget item.
-   */
-  void populate();
+  // populate this tree widget item if it has not been populated yet
+  // or if force is true
+  //
+  void populate(bool force = false);
 
-  /**
-   * @brief Check if this item has been populated already.
-   *
-   * @return true if this item has been populated, false otherwize.
-   */
-  bool isPopulated() const {
-    return m_Populated;
-  }
+  // check if this item has already been populated
+  //
+  bool isPopulated() const { return m_Populated; }
 
-  /**
-   * @brief Replace the entry corresponding to this item.
-   *
-   * @param entry The new entry.
-   */
+  // replace the entry corresponding to this item
+  //
   void setEntry(std::shared_ptr<MOBase::FileTreeEntry> entry) {
     m_Entry = entry;
   }
 
-  /**
-   * @brief Retrieve the entry corresponding to this item.
-   *
-   * @return the entry corresponding to this item.
-   */
+  // retrieve the entry corresponding to this item
+  //
   std::shared_ptr<MOBase::FileTreeEntry> entry() const {
     return m_Entry;
   }
 
-  /**
-   * @brief Overriden method to avoid propagating dataChanged events.
-   *
-   */
+  // overriden method to avoid propagating dataChanged events
+  //
   void setData(int column, int role, const QVariant& value) override;
+
+  ArchiveTreeWidgetItem* parent() const {
+    return static_cast<ArchiveTreeWidgetItem*>(QTreeWidgetItem::parent());
+  }
+
+  ArchiveTreeWidgetItem* child(int index) const {
+    return static_cast<ArchiveTreeWidgetItem*>(QTreeWidgetItem::child(index));
+  }
 
 protected:
 
-  // The entry of the item:
   std::shared_ptr<MOBase::FileTreeEntry> m_Entry;
-
-  // Populated or not (when expanded):
   bool m_Populated = false;
 
   friend class ArchiveTreeWidget;
 };
 
 
-/**
- * @brief QT tree widget used to display the content of an archive in the manual installation dialog
- **/
+// Qt tree widget used to display the content of an archive in the manual installation
+// dialog
 class ArchiveTreeWidget : public QTreeWidget
 {
 
@@ -100,48 +90,32 @@ class ArchiveTreeWidget : public QTreeWidget
 
 public:
 
-  /**
-   * @brief Default constructor for the UI.
-   *
-   */
-  explicit ArchiveTreeWidget(QWidget *parent = 0);
+  explicit ArchiveTreeWidget(QWidget* parent = 0);
 
 signals:
 
-  /**
-   * @brief Emitted after a tree widget item is moved from one
-   * parent to another.
-   *
-   * @param source The item being moved.
-   * @param target The item to which the source is added.
-   *
-   */
-  void itemMoved(ArchiveTreeWidgetItem *source, ArchiveTreeWidgetItem *target);
+  // emitted after a tree widget item is moved from one parent to another
+  //
+  void itemMoved(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target);
 
-  /**
-   * @brief Emitted when a tree widget item is checked or unchecked.
-   *
-   * Unlike itemChanged() or dataChanged(), this signal is only emitted
-   * for the item that was changed, not its parent or child.
-   *
-   * This signal is emitted after the tree has been updated, and after all the 
-   * itemChanged() or dataChanged() signals.
-   *
-   * @param item Item that was triggered the change.
-   */
+  // emitted when a tree widget item is checked or unchecked
+  //
+  // unlike itemChanged() or dataChanged(), this signal is only emitted
+  // for the item that was changed, not its parent or child
+  //
+  // this signal is emitted after the tree has been updated, and after all the
+  // itemChanged() or dataChanged() signals
+  //
   void treeCheckStateChanged(ArchiveTreeWidgetItem* item);
 
 public slots:
 
 protected:
 
-  /**
-   * @brief Slot that trigger the given item to be populated if it has not already
-   *     been.
-   *
-   * @param item The item to populate.
-   */
-  virtual void populateItem(QTreeWidgetItem* item);
+  // slot that trigger the given item to be populated if it has not already
+  // been
+  //
+  void populateItem(QTreeWidgetItem* item);
 
   virtual void dragEnterEvent(QDragEnterEvent *event) override;
   virtual void dragMoveEvent(QDragMoveEvent *event) override;
@@ -149,16 +123,17 @@ protected:
 
 private:
 
-  bool testMovePossible(QTreeWidgetItem *source, QTreeWidgetItem *target);
+  bool testMovePossible(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target);
 
-  /**
-   * @brief Emit the itemCheckStateChanged event.
-   * 
-   * @param item Item that was changed.
-   */
+  // refresh the given item (after a drop)
+  //
+  void refreshItem(ArchiveTreeWidgetItem* item);
+
+  // emit the itemCheckStateChanged event
+  //
   void emitTreeCheckStateChanged(ArchiveTreeWidgetItem* item);
 
-  // The widget item that emitted the dataChanged event:
+  // the widget item that emitted the dataChanged event
   ArchiveTreeWidgetItem* m_Emitter = nullptr;
 
   friend class ArchiveTreeWidgetItem;

--- a/src/installdialog.cpp
+++ b/src/installdialog.cpp
@@ -271,7 +271,7 @@ void InstallDialog::onItemMoved(ArchiveTreeWidgetItem* source, ArchiveTreeWidget
   // check if an entry exists with the same name, we check
   // in the tree widget to find unchecked items
   for (int i = 0; i < target->childCount(); ++i) {
-    auto* child = static_cast<ArchiveTreeWidgetItem*>(target->child(i));
+    auto* child = target->child(i);
     if (child->entry()->compare(source->entry()->name()) == 0) {
       // remove existing file and force check existing directory
       if (child->entry()->isFile()) {

--- a/src/installdialog.h
+++ b/src/installdialog.h
@@ -92,59 +92,9 @@ private:
 
   bool testForProblem();
   void updateProblems();
-
-  /**
-   * @brief Detach the entry of this item from its parent, and recursively detach
-   *     all of its parent if they become empty.
-   *
-   * @param item The item to detach.
-   */
-  void detachParents(ArchiveTreeWidgetItem* item);
-
-  /**
-   * @brief Re-attach the entry of this item to its parent, and recursively attach
-   *    all of its parent if they were empty (and thus detached).
-   *
-   * @param item The item to attach.
-   */
-  void attachParents(ArchiveTreeWidgetItem* item);
-
-  /**
-   * @brief Recursively re-insert all the entries below the given item in their
-   *     corresponding parents. This method does not recurse in items that have not 
-   *     been populated yet.
-   *
-   * @param item The top-level item to start.
-   */
-  void recursiveInsert(ArchiveTreeWidgetItem* item);
-
-  /**
-   * @brief Recursively detach all the entries below the given item from their
-   *     corresponding parents. This method does not recurse in items that have not 
-   *     been populated yet.
-   *
-   * @param item The top-level item to start.
-   */
-  void recursiveDetach(ArchiveTreeWidgetItem* item);
-
-  /**
-   * @brief Set the data root widget.
-   */
-  void setDataRoot(ArchiveTreeWidgetItem* const root);
-
-  /**
-   * @brief Create a directory under the given tree item, asking
-   *     the user for a name.
-   *
-   * @param treeItem Parent item of the directory.
-   */
-  void createDirectoryUnder(ArchiveTreeWidgetItem *treeItem);
+  void createDirectoryUnder(ArchiveTreeWidgetItem* treeItem);
 
 private slots:
-
-  // The two slots to connect to the tree:
-  void onItemMoved(ArchiveTreeWidgetItem* source, ArchiveTreeWidgetItem* target);
-  void onTreeCheckStateChanged(ArchiveTreeWidgetItem* item);
 
   // Automatic slots that are directly bound to the UI:
   void on_treeContent_customContextMenuRequested(QPoint pos);
@@ -159,24 +109,16 @@ private:
   // Name of the "data" directory:
   QString m_DataFolderName;
 
+  // the tree root is the initial root that will never change (should be const
+  // but cannot be since the parent tree cannot be constructed in the member
+  // initializer list)
+  //
+  // the tree root is not actually added to the tree, but is used to maintain
+  // the state of the tree and not lose entries when unsetting data root
+  //
   ArchiveTreeWidget *m_Tree;
+  ArchiveTreeWidgetItem* m_TreeRoot;
   QLabel *m_ProblemLabel;
-
-  // IMPORTANT: If you intend to work on this and understand this, read the detailed
-  // explanation at the beginning of the installdialog.cpp file.
-
-  // The tree root is the initial root that will never change (should be const
-  // but cannot be since the parent tree cannot be consstructed in the member
-  // initializer list):
-  ArchiveTreeWidgetItem *m_TreeRoot;
-
-  // The data root is the real widget of the current data. This widget
-  // is not the real root that is added to the tree.
-  ArchiveTreeWidgetItem *m_DataRoot;
-
-  // This is the actual tree in the widget  (should be const but cannot be since 
-  // the parent tree cannot be consstructed in the member initializer list):
-  ArchiveTreeWidgetItem *m_ViewRoot;
 
 };
 

--- a/src/installer_manual_en.ts
+++ b/src/installer_manual_en.ts
@@ -2,6 +2,30 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
 <context>
+    <name>ArchiveTreeWidget</name>
+    <message>
+        <location filename="archivetree.cpp" line="240"/>
+        <location filename="archivetree.cpp" line="250"/>
+        <source>Cannot drop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="archivetree.cpp" line="241"/>
+        <source>Cannot drop &apos;%1&apos; into one of its subfolder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="archivetree.cpp" line="252"/>
+        <source>A file &apos;%1&apos; already exists in folder &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="archivetree.cpp" line="253"/>
+        <source>A folder &apos;%1&apos; already exists in folder &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>InstallDialog</name>
     <message>
         <location filename="installdialog.ui" line="20"/>
@@ -94,32 +118,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="329"/>
+        <location filename="installdialog.cpp" line="343"/>
         <source>Set as &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="333"/>
+        <location filename="installdialog.cpp" line="347"/>
         <source>Unset &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="342"/>
+        <location filename="installdialog.cpp" line="356"/>
         <source>Create directory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="345"/>
+        <location filename="installdialog.cpp" line="359"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="356"/>
+        <location filename="installdialog.cpp" line="370"/>
         <source>Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="357"/>
+        <location filename="installdialog.cpp" line="371"/>
         <source>This mod was probably NOT set up correctly, most likely it will NOT work. You should first correct the directory layout using the content-tree.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,7 +151,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>InstallerManual</name>
     <message>
-        <location filename="installermanual.cpp" line="61"/>
+        <location filename="installermanual.cpp" line="56"/>
+        <source>Manual Installer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="installermanual.cpp" line="66"/>
         <source>Fallback installer for mods that can be extracted but can&apos;t be handled by another installer</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/installer_manual_en.ts
+++ b/src/installer_manual_en.ts
@@ -4,23 +4,23 @@
 <context>
     <name>ArchiveTreeWidget</name>
     <message>
-        <location filename="archivetree.cpp" line="240"/>
-        <location filename="archivetree.cpp" line="250"/>
+        <location filename="archivetree.cpp" line="419"/>
+        <location filename="archivetree.cpp" line="429"/>
         <source>Cannot drop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="archivetree.cpp" line="241"/>
+        <location filename="archivetree.cpp" line="420"/>
         <source>Cannot drop &apos;%1&apos; into one of its subfolder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="archivetree.cpp" line="252"/>
+        <location filename="archivetree.cpp" line="431"/>
         <source>A file &apos;%1&apos; already exists in folder &apos;%2&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="archivetree.cpp" line="253"/>
+        <location filename="archivetree.cpp" line="432"/>
         <source>A folder &apos;%1&apos; already exists in folder &apos;%2&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
     </message>
     <message>
         <location filename="installdialog.ui" line="46"/>
-        <location filename="installdialog.cpp" line="239"/>
+        <location filename="installdialog.cpp" line="125"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -73,77 +73,77 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="239"/>
+        <location filename="installdialog.cpp" line="125"/>
         <source>Enter a directory name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="139"/>
+        <location filename="installdialog.cpp" line="95"/>
         <source>Cannot check the content of &lt;%1&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="140"/>
+        <location filename="installdialog.cpp" line="96"/>
         <source>The plugin for the current game does not provide a way to check the content of &lt;%1&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="145"/>
+        <location filename="installdialog.cpp" line="101"/>
         <source>The content of &lt;%1&gt; looks valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="146"/>
+        <location filename="installdialog.cpp" line="102"/>
         <source>The content of &lt;%1&gt; seems valid for the current game.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="150"/>
+        <location filename="installdialog.cpp" line="106"/>
         <source>The content of &lt;%1&gt; does not look valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="151"/>
+        <location filename="installdialog.cpp" line="107"/>
         <source>The content of &lt;%1&gt; is probably not valid for the current game.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="231"/>
+        <location filename="installdialog.cpp" line="117"/>
         <source>Cannot create directory under a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="247"/>
+        <location filename="installdialog.cpp" line="133"/>
         <source>A directory or file with that name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="343"/>
+        <location filename="installdialog.cpp" line="152"/>
         <source>Set as &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="347"/>
+        <location filename="installdialog.cpp" line="156"/>
         <source>Unset &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="356"/>
+        <location filename="installdialog.cpp" line="165"/>
         <source>Create directory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="359"/>
+        <location filename="installdialog.cpp" line="168"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="370"/>
+        <location filename="installdialog.cpp" line="179"/>
         <source>Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="371"/>
+        <location filename="installdialog.cpp" line="180"/>
         <source>This mod was probably NOT set up correctly, most likely it will NOT work. You should first correct the directory layout using the content-tree.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Merge folder instead of replacing them and properly update the display.

Fixes ModOrganizer2/modorganizer#1364

---

- I did not add popup like "do you want to merge", etc., because 1) it's only a virtual move so the impact are negligible (just cancel and restart) and 2) from experience, you're replacing/merging stuff most of the time so you'd get tons of popups.
- For the rare case where you try to "replace" a folder by a file or a file for a folder, I show a popup and abort the move (before moving anything in case there are multiple selected files).
- I removed drop "between" items because I maintain the filename order, so you can only drop like you would in explorer.
- There are a lots of changing because I cleaned the code style a bit and moved stuff from `InstallDialog` to `ArchiveTree` because it makes much more sense but the biggest changes are in `ArchiveTree::dropEvent` and `InstallDialog::onItemMoved`.