### PR TITLE
Fix add directory.

### DIFF
--- a/src/installdialog.cpp
+++ b/src/installdialog.cpp
@@ -134,6 +134,7 @@ void InstallDialog::createDirectoryUnder(ArchiveTreeWidgetItem* item)
       return;
     }
 
+    item->setExpanded(true);
     auto* newItem = m_Tree->addDirectory(item, result);
     m_Tree->scrollToItem(newItem);
   }

--- a/src/installer_manual_en.ts
+++ b/src/installer_manual_en.ts
@@ -118,32 +118,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="152"/>
+        <location filename="installdialog.cpp" line="153"/>
         <source>Set as &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="156"/>
+        <location filename="installdialog.cpp" line="157"/>
         <source>Unset &lt;%1&gt; directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="165"/>
+        <location filename="installdialog.cpp" line="166"/>
         <source>Create directory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="168"/>
+        <location filename="installdialog.cpp" line="169"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="179"/>
+        <location filename="installdialog.cpp" line="180"/>
         <source>Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installdialog.cpp" line="180"/>
+        <location filename="installdialog.cpp" line="181"/>
         <source>This mod was probably NOT set up correctly, most likely it will NOT work. You should first correct the directory layout using the content-tree.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Force expansion of item before creating a directory to populate it.

It's possible to force populate without expanding but I don't see the point, if you create a directory inside another one you probably want it expanded anyway.